### PR TITLE
Read config file every 10s before pinging server

### DIFF
--- a/statusDisp.py
+++ b/statusDisp.py
@@ -15,11 +15,10 @@ import threading
 from jsonconfig import JsonConfig
 
 canReachServer = False
-#host = JsonConfig('/opt/amya/configs/pickled.config.json').get('mqtt', 'connection','host', None)
-config = JsonConfig('/storage/configs/pickled.config.json')
-host = config.get('mqtt','connection','host')
 def ping_server():
     global canReachServer
+    config = JsonConfig('/storage/configs/pickled.config.json')
+    host = config.get('mqtt','connection','host')
     try:
         canReachServer = ping(host, count=1).success()
     except:


### PR DESCRIPTION
Put the config file read INSIDE of the ping thread so that it reads in any changes that may have been made to the config file.